### PR TITLE
Debug Party 7 et 8 juillet

### DIFF
--- a/doliwoo.php
+++ b/doliwoo.php
@@ -211,6 +211,7 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 				 * @return void
 				 */
 				public function reschedule_import_products() {
+					$this->settings = new Doliwoo_WC_Integration();
 					$delay = $this->settings->delay_update;
 					wp_clear_scheduled_hook( 'import_products' );
 					wp_schedule_event( time(), $delay, 'import_products' );

--- a/includes/class-dolibarr.php
+++ b/includes/class-dolibarr.php
@@ -483,13 +483,40 @@ class Doliwoo_Dolibarr {
 		add_post_meta( $post_id, 'dolibarr_type', $dolibarr_product->type, true );
 		update_post_meta( $post_id, '_sku', $dolibarr_product->ref );
 		update_post_meta( $post_id, '_purchase_note', $dolibarr_product->note );
-/*		update_post_meta( $post_id, '_regular_price', $dolibarr_product->price_net );
-		update_post_meta( $post_id, '_sale_price', $dolibarr_product->price_net );
-		update_post_meta( $post_id, '_price', $dolibarr_product->price_net );*/
-		// Update in July 2016 CMOINON => get the price instead if the price_net witch is false with de webservice 
-		// if we have multiple-price 
-		update_post_meta( $post_id, '_regular_price', $dolibarr_product->price );
-		update_post_meta( $post_id, '_price', $dolibarr_product->price );
+
+
+		// Update in July 2016 CMOINON => 
+		// if in woocommerce price not include tax
+		//  => if not price_list => price_net else multiprice[level_price]
+		// else woocommerce price include tax
+		//  => if not price_list => price else multiprice_ttc[level_price]    
+
+		$level = $this->settings->dolibarr_price_level ;
+
+		if ($level > count($dolibarr_product->multiprices)) {
+			$level = '';
+		} 
+		if ( 'no' === get_option( 'woocommerce_prices_include_tax' ) ) {
+			if ( '' === $level) {
+				update_post_meta( $post_id, '_regular_price', $dolibarr_product->price_net );
+				update_post_meta( $post_id, '_sale_price', $dolibarr_product->price_net );
+				update_post_meta( $post_id, '_price', $dolibarr_product->price_net );
+			} else {
+				update_post_meta( $post_id, '_regular_price', $dolibarr_product->multiprices[$level-1] );
+				update_post_meta( $post_id, '_sale_price', $dolibarr_product->multiprices[$level-1] );
+				update_post_meta( $post_id, '_price', $dolibarr_product->multiprices[$level-1] );
+			}
+		} else {
+			if ( '' === $level) {
+				update_post_meta( $post_id, '_regular_price', $dolibarr_product->price );
+				update_post_meta( $post_id, '_sale_price', $dolibarr_product->price );
+				update_post_meta( $post_id, '_price', $dolibarr_product->price );
+			} else {
+				update_post_meta( $post_id, '_regular_price', $dolibarr_product->multiprices_ttc[$level-1] );
+				update_post_meta( $post_id, '_sale_price', $dolibarr_product->multiprices_ttc[$level-1] );
+				update_post_meta( $post_id, '_price', $dolibarr_product->multiprices_ttc[$level-1] );
+			}
+		}
 
 		update_post_meta( $post_id, '_visibility', 'visible' );
 		update_post_meta(

--- a/includes/class-dolibarr.php
+++ b/includes/class-dolibarr.php
@@ -368,6 +368,7 @@ class Doliwoo_Dolibarr {
 	 * @return void
 	 */
 	public function dolibarr_import_products() {
+		
 		try {
 			$soap_client = new SoapClient(
 				$this->ws_endpoint . self::PRODUCT_ENDPOINT . self::WSDL_MODE
@@ -507,13 +508,16 @@ class Doliwoo_Dolibarr {
 			}
 		}
 
-		// Check if the product has images 
-		$the_product = $this->dolibarr_images_exit($dolibarr_product->id);
+		// If synchronize images with Dolibarr
+		if ( 'yes' === $this->settings->dolibarr_images_sync ) {
+			// Check if the product has images 
+			$the_product = $this->dolibarr_images_exit($dolibarr_product->id);
 
-		// Product images management
-		if ( $the_product && ! empty($the_product->images) ) {
-			$this->import_product_images( $the_product, $post_id );
-		}
+			// Product images management
+			if ( $the_product && ! empty($the_product->images) ) {
+				$this->import_product_images( $the_product, $post_id );
+			}
+		}	
 
 		// Cleanup
 		wc_delete_product_transients( $post_id );

--- a/includes/class-dolibarr.php
+++ b/includes/class-dolibarr.php
@@ -79,6 +79,14 @@ class Doliwoo_Dolibarr {
 		 * We use non WSDL mode to workaround Dolibarr broken declaration marking all the fields as required
 		 * when they're not.
 		 */
+
+		// if no synchronization order with Dolibarr
+		if ( $this->settings->dolibarr_order_sync === 'no' ) {
+			// Do nothing
+			return ;
+		}
+
+
 		try {
 			$soap_client = new SoapClient(
 				null,
@@ -110,12 +118,11 @@ class Doliwoo_Dolibarr {
 			$order->thirdparty_id = $thirdparty_id;
 		} else {
 			if ( 0 === intval( get_user_meta( $user_id, 'billing_company', true ) ) ) {
-
 				// CMOINON (OPEN-DSI) Correctif 
 				//if ( wp_verify_nonce( 'woocommerce-cart' ) ) {
 
-				/* Suppression de lal vérification => contrôle à revoir dans un deuxième temps
-				if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'] , 'woocommerce-process_checkout')) {
+				// Suppression de lal vérification => contrôle à revoir dans un deuxième temps
+/*				if ( isset( $_POST['_wpnonce'] )  && wp_verify_nonce( $_POST['_wpnonce'] , 'woocommerce-process_checkout')) {
 					$billing_company = $_POST['billing_company'];
 				} else {
 					// TODO: fail message?

--- a/includes/class-wc-integration.php
+++ b/includes/class-wc-integration.php
@@ -69,6 +69,9 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 		/** @var boolean Parameter to disable images load */
 		public $dolibarr_images_sync;		
 
+		/** @var int Price level to load */
+		public $dolibarr_price_level;		
+
 		/**
 		 * Init and hook in the integration.
 		 */
@@ -93,6 +96,7 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 			$this->dolibarr_generic_id  = $this->get_option( 'dolibarr_generic_id' );
 			$this->dolibarr_order_sync  = $this->get_option( 'dolibarr_order_sync' );
 			$this->dolibarr_images_sync  = $this->get_option( 'dolibarr_images_sync' );
+			$this->dolibarr_price_level  = $this->get_option( 'dolibarr_price_level' );
 
 			// Actions
 			add_action(
@@ -185,12 +189,19 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 					'default'     => '',
 				),
 
+				'dolibarr_price_level'  => array(
+					'title'       => __( 'Price Level for price', 'doliwoo' ),
+					'description' => __( 'The level of price to load for the product. If no price list, leave blank.', 'doliwoo' ),
+					'type'        => 'text',
+					'desc_tip'    => false,
+					'default'     => '',
+				),				
+
 				'dolibarr_order_sync'     => array(
 					'title'        => __( 'Order synchronisation', 'doliwoo' ),
 					'desc'        => __( 'Dolibarr order synchronisation', 'doliwoo' ),
 					'description' => __( 'If is checked the orders will be synchronized with Dolibarr ', 'doliwoo' ),
 					'type'        => 'checkbox',
-					'checkboxgroup'   => 'start',
 					'desc_tip'    => false,
 					'default'	  => 'yes'	
 				),	
@@ -199,7 +210,6 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 					'desc'        => __( 'Dolibarr images synchronisation', 'doliwoo' ),
 					'description' => __( 'If is checked the images of product in Dolibarr will be loaded in WooCommerce', 'doliwoo' ),
 					'type'        => 'checkbox',
-					'checkboxgroup'   => 'start',
 					'desc_tip'    => false,
 					'default'	  => 'yes'	
 				),											

--- a/includes/class-wc-integration.php
+++ b/includes/class-wc-integration.php
@@ -66,6 +66,9 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 		/** @var boolean Parameter to disable order synchronization */
 		public $dolibarr_order_sync;
 
+		/** @var boolean Parameter to disable images load */
+		public $dolibarr_images_sync;		
+
 		/**
 		 * Init and hook in the integration.
 		 */
@@ -89,6 +92,7 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 			$this->dolibarr_category_id = $this->get_option( 'dolibarr_category_id' );
 			$this->dolibarr_generic_id  = $this->get_option( 'dolibarr_generic_id' );
 			$this->dolibarr_order_sync  = $this->get_option( 'dolibarr_order_sync' );
+			$this->dolibarr_images_sync  = $this->get_option( 'dolibarr_images_sync' );
 
 			// Actions
 			add_action(
@@ -189,7 +193,16 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 					'checkboxgroup'   => 'start',
 					'desc_tip'    => false,
 					'default'	  => 'yes'	
-				),								
+				),	
+				'dolibarr_images_sync'     => array(
+					'title'        => __( 'Images synchronisation', 'doliwoo' ),
+					'desc'        => __( 'Dolibarr images synchronisation', 'doliwoo' ),
+					'description' => __( 'If is checked the images of product in Dolibarr will be loaded in WooCommerce', 'doliwoo' ),
+					'type'        => 'checkbox',
+					'checkboxgroup'   => 'start',
+					'desc_tip'    => false,
+					'default'	  => 'yes'	
+				),											
 				'dolibarr_version'     => array(
 					'title'       => __( 'Dolibarr version', 'doliwoo' ),
 					'description' => __( 'If the webservice communication is OK, it displays your Dolibarr version', 'doliwoo' ),

--- a/includes/class-wc-integration.php
+++ b/includes/class-wc-integration.php
@@ -63,6 +63,9 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 		/** @var int[] The distant Dolibarr version */
 		private $dolibarr_version;
 
+		/** @var boolean Parameter to disable order synchronization */
+		public $dolibarr_order_sync;
+
 		/**
 		 * Init and hook in the integration.
 		 */
@@ -85,6 +88,7 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 			$this->dolibarr_entity      = $this->get_option( 'dolibarr_entity' );
 			$this->dolibarr_category_id = $this->get_option( 'dolibarr_category_id' );
 			$this->dolibarr_generic_id  = $this->get_option( 'dolibarr_generic_id' );
+			$this->dolibarr_order_sync  = $this->get_option( 'dolibarr_order_sync' );
 
 			// Actions
 			add_action(
@@ -176,6 +180,16 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 					'desc_tip'    => false,
 					'default'     => '',
 				),
+
+				'dolibarr_order_sync'     => array(
+					'title'        => __( 'Order synchronisation', 'doliwoo' ),
+					'desc'        => __( 'Dolibarr order synchronisation', 'doliwoo' ),
+					'description' => __( 'If is checked the orders will be synchronized with Dolibarr ', 'doliwoo' ),
+					'type'        => 'checkbox',
+					'checkboxgroup'   => 'start',
+					'desc_tip'    => false,
+					'default'	  => 'yes'	
+				),								
 				'dolibarr_version'     => array(
 					'title'       => __( 'Dolibarr version', 'doliwoo' ),
 					'description' => __( 'If the webservice communication is OK, it displays your Dolibarr version', 'doliwoo' ),
@@ -218,7 +232,7 @@ if ( ! class_exists( 'Doliwoo_WC_Integration' ) ) :
 			?>
 			<tr valign="top">
 				<th scope="row" class="titledesc">
-					<label for="<?php echo esc_attr( $field ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
+					<label for="<?php echo esc_attr( $field ); ?>"><?php echo  wp_kses_post( $data['title'] ); ?></label>
 					<?php esc_html_e( $this->get_tooltip_html( $data ) ); ?>
 				</th>
 				<td class="forminp">

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -47,9 +47,12 @@ class Doliwoo_WC_Tax extends WC_Tax {
 		foreach ( $tax_classes as $class ) {
 			$rates = $this->get_rates( $class );
 			$rates_values = array_values( $rates );
-			if ( floatval( $rates_values[0]['rate'] ) === $tax_rate ) {
-				// Use the first class found
-				return $class;
+			// Ajout CMO - Juillet 2016
+			if(array_key_exists(0, $rates_values)){
+				if ( floatval( $rates_values[0]['rate'] ) === $tax_rate ) {
+					// Use the first class found
+					return $class;
+				}
 			}
 		}
 


### PR DESCRIPTION
Ajout d'un **paramétre dans Doliwoo pour désactiver l'envoi des commandes**.
**Paramètre pour ne pas synchroniser les photos**
**Ajout de la gestion des niveaux de prix** et prise en compte du paramètrage de Woocommerce pour la TVA (prix saisit HT ou TTC)
Si dans Woocommerce, saisie des prix Net (HT)
    Si on a un niveau de prix 
        on prend alors multiprice du niveau de prix 
    Sinon 
        on prend le price_net du produit
Si saisie des prix TTC dans Woocommerce
    Si on a un niveau de prix 
        on prend alors multiprice_ttc du niveau de prix 
    Sinon 
        on prend le price du produit
Règle complémentaire pour eviter de faire bugger
Si le niveau de prix paramètre n'existe pas on prend le prix du produit. 
**Création du tiers**
Recherche sur nom et prénom ajouté (code à revoir intégralement)
